### PR TITLE
Slowmotion triggers when seen

### DIFF
--- a/Assets/Scripts/Monster/PatrollingMonster.cs
+++ b/Assets/Scripts/Monster/PatrollingMonster.cs
@@ -95,7 +95,12 @@ public class PatrollingMonster : MonoBehaviour {
             {
                 
                 spottedCue.SetActive(true);
-               
+
+                if (!player.slowMo)// Upon player collision with linecast/monster-vision, their speed is reduced
+                {
+                    player.slowMo = true;
+                }
+
                 //Tests which direction the monster is facing
                 if (!facingRight) 
 				{

--- a/Assets/Scripts/Player/PlayerControl.cs
+++ b/Assets/Scripts/Player/PlayerControl.cs
@@ -63,12 +63,13 @@ public class PlayerControl : MonoBehaviour
             //it shift key is hit, players speed is 2 times the speed
             playerSpeed = normalSpeed * 2;
             print("shift key was pressed");
-        }
+        }/* 
         else
         {
             // if not then normal speed resumes
             playerSpeed = normalSpeed;
         }
+            */
     }
     void LateUpdate()
     {
@@ -98,7 +99,7 @@ public class PlayerControl : MonoBehaviour
             playerSpeed = slowMoSpeed;
         }
 
-        else  //when slowMo is false, the player will move normaly
+        else  //when slowMo is false, the player will move normally
         {
             playerSpeed = normalSpeed;
         }
@@ -164,6 +165,11 @@ public class PlayerControl : MonoBehaviour
                 {
                     sprite.sortingOrder = sortingOrder;
                     hide = false;
+
+                    if (slowMo) //Disables slowmotion speed upon hiding
+                    {
+                        slowMo = false;
+                    }
                 }
             }
                


### PR DESCRIPTION
Upon being seen by an enemy, the player's speed is reduced(permanently?) until they hide.

Note: There was some code involving the player's sprint mechanic that conflicted with the slow-motion code. I've commented it out here, but since the two are similar, I think they could be organized in a better way.
