### PR TITLE
Vision Less Patrolling Enemy

### DIFF
--- a/Assets/Prefabs/VisionLessPatrolEnemy.prefab
+++ b/Assets/Prefabs/VisionLessPatrolEnemy.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &131142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 429508}
+  - 212: {fileID: 21261082}
+  - 61: {fileID: 6182434}
+  - 114: {fileID: 11426506}
+  m_Layer: 0
+  m_Name: VisionLessPatrolEnemy
+  m_TagString: PatrolEnemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &429508
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 131142}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 24.5, y: 5.40999985, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!61 &6182434
+BoxCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 131142}
+  m_Enabled: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Size: {x: 3.19000006, y: 3.78999996}
+--- !u!114 &11426506
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 131142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38418c75121245c48a0dcda9794dbac6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movement: 0
+  speed: 2
+  speed2: 0
+  counter: 0
+  distance: 0
+  patrolDistance: 15
+--- !u!212 &21261082
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 131142}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 0
+  m_ReflectionProbeUsage: 0
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_ImportantGI: 0
+  m_AutoUVMaxDistance: .5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: d4c83c50108f6bb45ac86521458d379e, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: patrolDistance
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: facingRight
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 131142}
+  m_IsPrefabParent: 1

--- a/Assets/Prefabs/VisionLessPatrolEnemy.prefab.meta
+++ b/Assets/Prefabs/VisionLessPatrolEnemy.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72bb42a0141910747a271b7919000e29
+timeCreated: 1444026887
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/VisionLessPatrolEnemySpawner.prefab
+++ b/Assets/Prefabs/VisionLessPatrolEnemySpawner.prefab
@@ -1,0 +1,105 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &150150
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 452112}
+  - 212: {fileID: 21279074}
+  - 114: {fileID: 11440730}
+  m_Layer: 0
+  m_Name: VisionLessPatrolEnemySpawner
+  m_TagString: Spawner
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &452112
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 150150}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 29.3700008, y: 13.96, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &11440730
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 150150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6f4a93322d9d845adf3af510e9ab46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  obj: {fileID: 131142, guid: 72bb42a0141910747a271b7919000e29, type: 2}
+  spawnMin: 4
+  spawnMax: 5
+  maxPool: 1
+  currentPool: 0
+  facingRight: 1
+--- !u!212 &21279074
+SpriteRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 150150}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 0
+  m_ReflectionProbeUsage: 0
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_ImportantGI: 0
+  m_AutoUVMaxDistance: .5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300000, guid: d4c83c50108f6bb45ac86521458d379e, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: m_TagString
+      value: Spawner
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: facingRight
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: spawnMin
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: spawnMax
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: maxPool
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 150150}
+  m_IsPrefabParent: 1

--- a/Assets/Prefabs/VisionLessPatrolEnemySpawner.prefab.meta
+++ b/Assets/Prefabs/VisionLessPatrolEnemySpawner.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3cf35c1537f76e4f95722ed6279dd56
+timeCreated: 1444035444
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Monster/VisionLessPatrollingMonster.cs
+++ b/Assets/Scripts/Monster/VisionLessPatrollingMonster.cs
@@ -1,0 +1,70 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+public class VisionLessPatrollingMonster : MonoBehaviour {
+	
+	Vector3 startPos;
+	private bool facingRight = true;
+	public float movement;
+	public float speed = 2.0f;
+	public float distance;
+	public int patrolDistance = 5;
+	//to access methods and variables from the spawner
+	private VisionLessPatrollingMonsterSpawner obj;
+
+	// Use this for initialization
+	void Start ()
+	{
+		//Get the starting position of the enemy
+		startPos = gameObject.transform.position;
+		//Grab the spawner and get its script component
+		obj = GameObject.Find("VisionLessPatrolEnemySpawner").GetComponent<VisionLessPatrollingMonsterSpawner> ();
+		//If the spawner is facing left...
+		if (!obj.facingRight) 
+		{	//then flip the monsters it spawns to go left
+			FlipEnemy ();
+		}
+	}
+	
+	// Update is called once per framed
+	void Update () 
+	{	
+
+		//Update the enemy position every frame
+		Vector2 currentPos = gameObject.transform.position;
+
+		//Calculate the distance it has traveled
+		distance = currentPos.x - startPos.x;		
+		//Enemy facing and movement to the left
+		if (!facingRight) 
+		{
+			movement = speed * Time.deltaTime;
+			transform.Translate (-movement, 0, 0);
+		}
+		//Enemy facing and movement to the right
+		else 
+		{
+			movement = speed * Time.deltaTime;
+			transform.Translate (movement, 0, 0);
+		}
+		//If the monster has reached its target distance...	
+		if (distance > patrolDistance || distance < -patrolDistance) 
+		{	//then...
+			//Decrement the spawners current pool
+			obj.currentPool -= 1;
+			//Destroy the enemy once it reaches its target distance
+			Destroy (gameObject);				
+		}
+	}
+
+	//Function to reverse enemy movemeny position, left or right, to 
+	//test if line cast flips along with the monster
+	void FlipEnemy()
+	{
+		facingRight = !facingRight;
+		Vector3 theScale = transform.localScale;
+		theScale.x *= -1;
+		transform.localScale = theScale;
+	}	
+}

--- a/Assets/Scripts/Monster/VisionLessPatrollingMonster.cs.meta
+++ b/Assets/Scripts/Monster/VisionLessPatrollingMonster.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 38418c75121245c48a0dcda9794dbac6
+timeCreated: 1444014278
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Monster/VisionLessPatrollingMonsterSpawner.cs
+++ b/Assets/Scripts/Monster/VisionLessPatrollingMonsterSpawner.cs
@@ -1,0 +1,49 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class VisionLessPatrollingMonsterSpawner : MonoBehaviour {
+
+	//The object that it will spawn, set in the inspector
+	public GameObject obj;
+	//Minimum time for object to spawn
+	public float spawnMin = 4f;
+	//Maximum time for object to spawn
+	public float spawnMax = 5f;
+	//Maximum amount of objects to be active at one time
+	public int maxPool = 1;
+	//Keeps track of how many are currently active
+	public int currentPool = 0;
+	//Set in inspector to make the spawner spawn objects that go left or right
+	public bool facingRight;
+
+	// Use this for initialization
+	void Start () 
+	{
+		//Make the sprite invisible during game. Sprite will be visible so you can see where it is in Scene mode
+		GetComponent<Renderer>().material.color = Color.clear;
+		//Start the spawn
+		Spawn ();
+	}
+	
+	// Update is called once per frame
+	void Update () 
+	{
+		//If the current pool has reached the maximum...
+		if (currentPool >= maxPool) 		
+		{	//then stop the spawning
+			CancelInvoke();
+		}
+		else
+		{	//else keep spawning within a certain window
+			Invoke ("Spawn", Random.Range (spawnMin, spawnMax));
+		}
+	}
+	//Spawn method
+	void Spawn()
+	{
+		//Spawn the object
+		Instantiate(obj, transform.position, Quaternion.identity);
+		//Increase amount in pool by 1
+		currentPool += 1;
+	}
+}

--- a/Assets/Scripts/Monster/VisionLessPatrollingMonsterSpawner.cs.meta
+++ b/Assets/Scripts/Monster/VisionLessPatrollingMonsterSpawner.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3a6f4a93322d9d845adf3af510e9ab46
+timeCreated: 1444026468
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A monster will spawn and patrol a certain distance before despawning. I
created a spawner prefab which turns invisible and won't react or
trigger with the player during game time. It will spawn vision less
patrolling enemies that will move in one direction and will kill the
player on contact. The direction of the spawner can be set in the
inspector and will spawn monsters going to the left or right depending
on whether "Facing Right" is selected or not.
