### PR TITLE
Adds click control to teleport doors

### DIFF
--- a/Assets/Scripts/LevelControl/TeleportDoors.cs
+++ b/Assets/Scripts/LevelControl/TeleportDoors.cs
@@ -20,14 +20,20 @@ public class TeleportDoors : MonoBehaviour
 	
 	void OnTriggerStay2D ( Collider2D other)
 	{
-        if (other.tag == "Player" && Input.GetKeyDown(KeyCode.Space))
+        
+        if (other.tag == "Player"  )
         {
             
+            if (Input.GetKeyDown(KeyCode.Space) || Input.GetMouseButton(0))
+            {
                 Debug.Log("Teleport Complete!"); // confirm that teleport is complete; this can be taken out
                 TeleportToExit2D(other);
+            }
             
         }
 	}
+
+
 	
 	void TeleportToExit2D ( Collider2D other )
 	{

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -150,23 +150,4 @@ QualitySettings:
     maximumLODLevel: 0
     particleRaycastBudget: 4096
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality:
-    Android: 2
-    BlackBerry: 2
-    GLES Emulation: 5
-    Nintendo 3DS: 5
-    PS3: 5
-    PS4: 5
-    PSM: 5
-    PSP2: 2
-    Samsung TV: 2
-    Standalone: 5
-    Tizen: 2
-    WP8: 5
-    Web: 5
-    WebGL: 3
-    Wii U: 5
-    Windows Store Apps: 5
-    XBOX360: 5
-    XboxOne: 5
-    iPhone: 2
+  m_PerPlatformDefaultQuality: {}


### PR DESCRIPTION
allows for user to click on the screen to teleport when colliding with a
door. I couldn't figure out how to activate teleport on when clicking doors and not the rest of the screen. I tried using an OnMouseDown method, but it didn't work.
