### PR TITLE
Fade only happens when player is in room

### DIFF
--- a/Assets/Scripts/LevelControl/FadingDarkness.cs
+++ b/Assets/Scripts/LevelControl/FadingDarkness.cs
@@ -8,15 +8,33 @@ using UnityEngine;
 public class FadingDarkness : MonoBehaviour
 {
     CanvasGroup canvasGroup;
+    CanvasGroup canvas1;
+    CanvasGroup canvas2;
+    CanvasGroup canvas3;
+    CanvasGroup canvas4;
+    CanvasGroup canvas5;
+
     float fadeSpeed;
     private float hiddenFadeSpeed; //fade speed when hidden
     public bool playerHidden = false; // bool that finds if player is hidden or not, also calls script from playerControl
+
+    // calls stuff from other scripts [declaring]
     PlayerControl playerScript;
+    PlayerControl fadingScript;
+
 
     void Awake()
     {
+        // a lot of information gained from other scripts mainly the CanvasGroup and PlayerControl
         playerScript = GameObject.FindGameObjectWithTag("Player").GetComponent<PlayerControl>();
+        fadingScript = GameObject.FindGameObjectWithTag("Player").GetComponent<PlayerControl>();
+
         canvasGroup = GetComponent<CanvasGroup>();
+        canvas1 = GameObject.FindGameObjectWithTag("Canvas1").GetComponent<CanvasGroup>();
+        canvas2 = GameObject.FindGameObjectWithTag("Canvas2").GetComponent<CanvasGroup>();
+        canvas3 = GameObject.FindGameObjectWithTag("Canvas3").GetComponent<CanvasGroup>();
+        canvas4 = GameObject.FindGameObjectWithTag("Canvas4").GetComponent<CanvasGroup>();
+        canvas5 = GameObject.FindGameObjectWithTag("Canvas5").GetComponent<CanvasGroup>();
     }
 
     void Start()
@@ -30,18 +48,90 @@ public class FadingDarkness : MonoBehaviour
 
     void Update()
     {
-        if (canvasGroup.alpha <= 0.85) //stops the fade at 0.85
+        // this is where the magic happens
+        if(fadingScript.canvas1)
         {
-
-            if (playerScript.hide) //when player is hidden...
+            if (canvas1.alpha <= 0.85) //stops the fade at 0.85
             {
-                canvasGroup.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
-            }
-            else
-            {
-                canvasGroup.alpha += Time.deltaTime * fadeSpeed; //default fade
-            }
 
+                if (playerScript.hide) //when player is hidden...
+                {
+                    canvas1.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
+                }
+                else
+                {
+                    canvas1.alpha += Time.deltaTime * fadeSpeed; //default fade
+                }
+            }
         }
+        if (fadingScript.canvas2)
+        {
+            canvas1.alpha = 0;  // after leaving canvas 1, canvas1 alpha goes to zero
+            if (canvas2.alpha <= 0.85) //stops the fade at 0.85
+            {
+
+                if (playerScript.hide) //when player is hidden...
+                {
+                    canvas2.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
+                }
+                else
+                {
+                    canvas2.alpha += Time.deltaTime * fadeSpeed; //default fade
+                }
+            }
+        }
+        if (fadingScript.canvas3)
+        {
+            canvas2.alpha = 0; // leaving canvas 2 will reset the canvas2 alpha to 0
+            if (canvas3.alpha <= 0.85) //stops the fade at 0.85
+            {
+
+                if (playerScript.hide) //when player is hidden...
+                {
+                    canvas3.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
+                }
+                else
+                {
+                    canvas3.alpha += Time.deltaTime * fadeSpeed; //default fade
+                }
+            }
+        }
+        if (fadingScript.flashingRoom)
+        {
+            canvas3.alpha = 0; // different than the other 2 since this doesn't have a canvas, its a flickering room, but anyway
+            // by leaving canvas3 the alpha resets.
+        }
+        if (fadingScript.canvas4)
+        {
+            if (canvas4.alpha <= 0.85) //stops the fade at 0.85
+            {
+                //doesnt have the reset because you were leaving the flickering room
+                if (playerScript.hide) //when player is hidden...
+                {
+                    canvas4.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
+                }
+                else
+                {
+                    canvas4.alpha += Time.deltaTime * fadeSpeed; //default fade
+                }
+            }
+        }
+        if (fadingScript.canvas5)
+        {
+            if (canvas5.alpha <= 0.85) //stops the fade at 0.85
+            {
+                canvas4.alpha = 0; //same as the top 4
+                if (playerScript.hide) //when player is hidden...
+                {
+                    canvas5.alpha += Time.deltaTime * hiddenFadeSpeed; //fade speed is multiplied
+                }
+                else
+                {
+                    canvas5.alpha += Time.deltaTime * fadeSpeed; //default fade
+                }
+            }
+        }
+
+
     }
 }

--- a/Assets/Scripts/Player/PlayerControl.cs
+++ b/Assets/Scripts/Player/PlayerControl.cs
@@ -35,7 +35,16 @@ public class PlayerControl : MonoBehaviour
     int hidingOrder = 0;//sorting layer when hidden
     int sortingOrder = 2;//sorting layer normally
 
-    
+    //bools that corresponds to the fading darkness mechanic
+    public bool fadingCanvas;
+    public bool canvas1;
+    public bool canvas2;
+    public bool canvas3;
+    public bool canvas4;
+    public bool canvas5;
+
+    public bool flashingRoom;
+
 
 
 
@@ -145,14 +154,43 @@ public class PlayerControl : MonoBehaviour
             normalSpeed = 0f;
         }
     }
+
+
     //allows actions when staying within collision area
     void OnTriggerStay2D(Collider2D col)
     {
         // OverlapPoint refers to world space instead of screen space, adjusting accordingly
         clickPosition.x = (Camera.main.ScreenToWorldPoint(Input.mousePosition).x);
         clickPosition.y = (Camera.main.ScreenToWorldPoint(Input.mousePosition).y);
-       
-       
+
+
+        //simple and repetitive that causes the canvases to be true, you can clearly see the pattern
+        if (col.gameObject.name == "RoomDetection")
+        {
+            canvas1 = true;
+        }
+        if (col.gameObject.name == "RoomDetection1")
+        {
+            canvas2 = true;
+        }
+        if (col.gameObject.name == "RoomDetection2")
+        {
+            canvas3 = true;
+        }
+        if (col.gameObject.name == "RoomDetection3")
+        {
+            flashingRoom = true;
+        }
+        if (col.gameObject.name == "RoomDetection4")
+        {
+            canvas4 = true;
+        }
+        if (col.gameObject.name == "RoomDetection5")
+        {
+            canvas5 = true;
+        }
+
+
         //Toggle Hide/Unhide
         if ((Input.GetKeyDown(KeyCode.Space) || (Input.GetMouseButtonDown(0)&& col.OverlapPoint(clickPosition))))
         {
@@ -178,13 +216,7 @@ public class PlayerControl : MonoBehaviour
           }     
         
         //if player colliders with an enemy and is not hidden
-        if (col.gameObject.tag == "PatrolEnemy" && hide == false)
-        {
-            //player is dead
-            isAlive = false;
-            //prevent player from moving
-            normalSpeed = 0f;
-        }
+
        ///gameover for stationary enemies handled in their own code
     }
     void FlipPlayer()


### PR DESCRIPTION
So these scripts aren't as condensed but they are just repetitive codes
from the others.

For this to work
we need to create individual canvases that has the fading Darkness
script, image component, and canvas group component. The amount of
canvases depends on how many rooms we need. With that said, each
canvases are tagged with "Canvas#" the # is just any number. For the
flickering lights, you dont need to create a canvas, just put the room
detection collider. This segways into the RoomDetection Colliders. You
create an empty child with only a box collider that acts as a trigger.
They don't need a tag but each RoomDetection Colliders need to be named
properly. The name is RoomDetection# same as before the # is just any
number corresponding the room. However, you do need this in the
flickering light since when you pass each room, the code is set so that
when you pass, the alpha in the previous room turns 0.

Confusing, i know, but it works, if you are confused ask me.
