### PR TITLE
Candidate Spotted Indicator Fix

### DIFF
--- a/Assets/Graphics/Thumbs.db.meta
+++ b/Assets/Graphics/Thumbs.db.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 364e2884b8750014bbf88436b0e6ee4f
+timeCreated: 1444330441
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Graphics/Thumbs.db.meta
+++ b/Assets/Graphics/Thumbs.db.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 364e2884b8750014bbf88436b0e6ee4f
-timeCreated: 1444330441
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/LevelControl/LevelControl.cs
+++ b/Assets/Scripts/LevelControl/LevelControl.cs
@@ -14,9 +14,9 @@ public class LevelControl : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+		Time.timeScale = 1f;
         spottedCue = GameObject.Find("SpottedIndicator");
         spottedCue.SetActive(false);
-        Time.timeScale = 1f;
         player = GameObject.Find("Player");
         gameOverPanel = GameObject.Find("GameOverPanel");
         //retryButton = GameObject.Find("RetryButton");

--- a/Assets/Scripts/Monster/CeilingMonster.cs
+++ b/Assets/Scripts/Monster/CeilingMonster.cs
@@ -11,6 +11,7 @@ public class CeilingMonster : MonoBehaviour
     bool isActive = true;           // check if its active or dazed
     bool isFalling = false;         // check if its falling
     bool isClimbing = false;        // check if its rising
+	bool isCaught = false;          // check to see if player is spotted
 
     public float stunTime = 10f;    // stun time
     public float fallSpeed = 5f;    // fall speed
@@ -63,22 +64,24 @@ public class CeilingMonster : MonoBehaviour
 
         // Trigger for Dropping the Ceiling Monster
 
-       
+		isCaught = false;
+		spottedCue.SetActive (false);
+
        if (leftTrigger.collider && leftTrigger.collider.tag == "Player")
        {
-                spottedCue.SetActive(true);
+				isCaught = true;
                 isFalling = true;
                 isClimbing = false;
        }
        else if (rightTrigger.collider && rightTrigger.collider.tag == "Player")
        {
-                spottedCue.SetActive(true);
+                isCaught = true;
                 isFalling = true;
                 isClimbing = false;
        }
        else if (centerTrigger.collider && centerTrigger.collider.tag == "Player")
        {
-                spottedCue.SetActive(true);
+                isCaught = true;
                 isFalling = true;
                 isClimbing = false;
        }
@@ -117,10 +120,15 @@ public class CeilingMonster : MonoBehaviour
         // Ceiling monster is dazed for 'stunTime' seconds
         if (!isActive)
         {
-            spottedCue.SetActive(false);
             StartCoroutine(DazeTimer(stunTime));
         }
     }
+
+	void LateUpdate()
+	{
+		if (isCaught == true)
+		spottedCue.SetActive (true);
+	}
 
     void OnTriggerEnter2D(Collider2D col)
     {

--- a/Assets/Scripts/Monster/ChasingMonster.cs
+++ b/Assets/Scripts/Monster/ChasingMonster.cs
@@ -6,6 +6,7 @@ public class ChasingMonster : MonoBehaviour {
 
     Vector3 startPos;
     private bool facingRight = true;
+	private bool isCaught = false;
     public float movement;
     public float speed = 2.0f;
     public float counter = 0;
@@ -88,37 +89,38 @@ public class ChasingMonster : MonoBehaviour {
         //Making the line cast
         RaycastHit2D EnemyVisionTrigger = Physics2D.Linecast(endCast, startCast);
         //check if the collider exists and if the collider is the player
-        if (EnemyVisionTrigger.collider && EnemyVisionTrigger.collider.tag == "Player")
-        {
-            ///this code runs when player is seen
-			if (player.hide == false)
-            {
-                
-                spottedCue.SetActive(true);
+		//this code runs when player is seen
+        if (EnemyVisionTrigger.collider && EnemyVisionTrigger.collider.tag == "Player" && player.hide == false)
+		{
+			spottedCue.SetActive (true);
+			isCaught = true;
 
-                if (!player.slowMo)// Upon player collision with linecast/monster-vision, their speed is reduced
-                {
-                    player.slowMo = true;
-                }
-
-                //Tests which direction the monster is facing
-                if (!facingRight) 
-				{
-					//Multiply the movement by the amount set in the inspector
-					transform.Translate (-movement * visionSpeedMultiplier, 0, 0);
-				}
-				else 
-				{
-					//Multiply the movement by the amount set in the inspector
-					transform.Translate (movement * visionSpeedMultiplier, 0, 0); 
-				}
+			if (!player.slowMo)
+			{
+				// Upon player collision with linecast/monster-vision, their speed is reduced
+				player.slowMo = true;
 			}
-            else
-            {
-                spottedCue.SetActive(false);
-            }
-            
+
+			//Tests which direction the monster is facing
+			if (!facingRight)
+			{
+				//Multiply the movement by the amount set in the inspector
+				transform.Translate (-movement * visionSpeedMultiplier, 0, 0);
+			}
+			else
+			{
+				//Multiply the movement by the amount set in the inspector
+				transform.Translate (movement * visionSpeedMultiplier, 0, 0); 
+			}
 		}
+		else
+		{
+			spottedCue.SetActive (false);
+		}
+
+		Debug.Log ("Spotted Cue: " + spottedCue.activeSelf);
+		Debug.Log ("Been caught: " + isCaught);
+		//Debug.Log ("Spotted Overlay: " + spottedCue.GetComponent<SpriteRenderer> ().enabled);
        
        
     }
@@ -126,7 +128,7 @@ public class ChasingMonster : MonoBehaviour {
     //test if line cast flips along with the monster
     void FlipEnemy()
     {
-        spottedCue.SetActive(false);
+        //spottedCue.SetActive(false);
         facingRight = !facingRight;
         Vector3 theScale = transform.localScale;
         theScale.x *= -1;

--- a/Assets/Scripts/Monster/ChasingMonster.cs
+++ b/Assets/Scripts/Monster/ChasingMonster.cs
@@ -2,11 +2,13 @@
 using UnityEngine.UI;
 using System.Collections;
 
-public class ChasingMonster : MonoBehaviour {
+public class ChasingMonster : MonoBehaviour
+{
 
     Vector3 startPos;
     private bool facingRight = true;
 	private bool isCaught = false;
+	private bool hitPlayer = false;
     public float movement;
     public float speed = 2.0f;
     public float counter = 0;
@@ -84,17 +86,18 @@ public class ChasingMonster : MonoBehaviour {
             FlipEnemy();
             startPos = gameObject.transform.position;
         }
+		// reinitialize caught detection
+		isCaught = false;
+		spottedCue.SetActive (false);
         //Visually see the line cast in scene mode, NOT GAME
         Debug.DrawLine(startCast, endCast, Color.green);
         //Making the line cast
-        RaycastHit2D EnemyVisionTrigger = Physics2D.Linecast(endCast, startCast);
+		RaycastHit2D EnemyVisionTrigger = Physics2D.Linecast(endCast, startCast);
         //check if the collider exists and if the collider is the player
 		//this code runs when player is seen
         if (EnemyVisionTrigger.collider && EnemyVisionTrigger.collider.tag == "Player" && player.hide == false)
 		{
-			spottedCue.SetActive (true);
 			isCaught = true;
-
 			if (!player.slowMo)
 			{
 				// Upon player collision with linecast/monster-vision, their speed is reduced
@@ -113,22 +116,18 @@ public class ChasingMonster : MonoBehaviour {
 				transform.Translate (movement * visionSpeedMultiplier, 0, 0); 
 			}
 		}
-		else
-		{
-			spottedCue.SetActive (false);
-		}
-
-		Debug.Log ("Spotted Cue: " + spottedCue.activeSelf);
-		Debug.Log ("Been caught: " + isCaught);
-		//Debug.Log ("Spotted Overlay: " + spottedCue.GetComponent<SpriteRenderer> ().enabled);
-       
-       
     }
+
+	void LateUpdate()
+	{
+		if (isCaught == true)
+			spottedCue.SetActive (true);
+	}
+
     //Function to reverse enemy movemeny position, left or right, to 
     //test if line cast flips along with the monster
     void FlipEnemy()
     {
-        //spottedCue.SetActive(false);
         facingRight = !facingRight;
         Vector3 theScale = transform.localScale;
         theScale.x *= -1;


### PR DESCRIPTION
Spotted Indicator is now working as intended.

The first issue is the nested if else statements. Setting the spottedCue.SetActive(false); is never reached unless a collision with the line cast occurs or when the chasing enemy flips. That is the reason why the spotted indicator remained active and deactivates when the enemy flips.

The second issue is consistency. After fixing the first issue the intended results was inconsistent and worked once the game reloads the stage. Upon looking at our source code for any other .SetActive occurance it turns out that having two .SetActive statements in one Update method will not work as intended even if it is logically correct. Separating activating and deactivating the spottedCue in Update and LateUpdate method fixed the issue.
