### PR TITLE
Candiated Chasing Monster Spotted Fix

### DIFF
--- a/Assets/Graphics/Background/Thumbs.db.meta
+++ b/Assets/Graphics/Background/Thumbs.db.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 775ed5edf2fdeb247aa3939c542f8121
-timeCreated: 1444927179
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Graphics/Enemies/TV Stalker/Thumbs.db.meta
+++ b/Assets/Graphics/Enemies/TV Stalker/Thumbs.db.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 28772e516095906409bc2a8822136298
-timeCreated: 1444928159
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Monster/ChasingMonster.cs
+++ b/Assets/Scripts/Monster/ChasingMonster.cs
@@ -8,6 +8,7 @@ public class ChasingMonster : MonoBehaviour
     Vector3 startPos;
     private bool facingRight = true;
     private bool isCaught = false;
+	private bool isPlayer = false;
     public float movement;
     public float speed = 2.0f;
     public float counter = 0;
@@ -88,14 +89,21 @@ public class ChasingMonster : MonoBehaviour
         }
         // reinitialize caught detection
         isCaught = false;
+		isPlayer = false;
         spottedCue.SetActive(false);
         
         //Visually see the line cast in scene mode, NOT GAME
         Debug.DrawLine(startCast, endCast, Color.green);
         //Making the line cast
-        RaycastHit2D EnemyVisionTrigger = Physics2D.Linecast(endCast, startCast);
+        RaycastHit2D[] EnemyVisionTrigger = Physics2D.LinecastAll(endCast, startCast);
+		
+		for (int i = 0; i < EnemyVisionTrigger.Length - 1; i++)
+		{
+			if(EnemyVisionTrigger[i].collider.tag == "Player")
+				isPlayer = true;
+		}
         //check if the collider exists and if the collider is the player
-        if (EnemyVisionTrigger.collider && EnemyVisionTrigger.collider.tag == "Player" && player.hide == false)
+        if (isPlayer == true && player.hide == false)
         {
             isCaught = true;
              // Upon player collision with linecast/monster-vision, their speed is reduced


### PR DESCRIPTION
Chasing Monster will now consistently spot the player.

Linecast will return the object that it first collides with, including the hiding spots. Using LinecastAll, we get an array of objects that it collided with. From there we look to see if the player object is there.
