### PR TITLE
DoorTransition

### DIFF
--- a/Assets/Scripts/LevelControl/TeleportDoors.cs
+++ b/Assets/Scripts/LevelControl/TeleportDoors.cs
@@ -35,7 +35,7 @@ public class TeleportDoors : MonoBehaviour
         clickPosition.x = Camera.main.ScreenToWorldPoint(Input.mousePosition).x;
         clickPosition.y = Camera.main.ScreenToWorldPoint(Input.mousePosition).y;
         ///currently, click must be on player
-        if (col.tag == "Player" && ((Input.GetKeyDown(KeyCode.Space)) || (col.OverlapPoint(clickPosition) && Input.GetMouseButtonDown(0))))
+        if ((col.tag == "Player" && cameraScript.follow == true) && ((Input.GetKeyDown(KeyCode.Space)) || (col.OverlapPoint(clickPosition) && Input.GetMouseButtonDown(0))))
         {
             
             if (exit != null)


### PR DESCRIPTION
Only allow the player to select a door when the camera is finished
transitioning.
