### PR TITLE
Level Complete Cutscene

### DIFF
--- a/Assets/Prefabs/MapManager/AtticLevel1.prefab
+++ b/Assets/Prefabs/MapManager/AtticLevel1.prefab
@@ -1,5 +1,25 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &106488
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 224: {fileID: 22433202}
+  - 222: {fileID: 22287426}
+  - 114: {fileID: 11425168}
+  - 225: {fileID: 22572656}
+  - 114: {fileID: 11443120}
+  - 61: {fileID: 6137562}
+  m_Layer: 0
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &110526
 GameObject:
   m_ObjectHideFlags: 0
@@ -49,7 +69,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &115100
 GameObject:
   m_ObjectHideFlags: 1
@@ -95,7 +115,7 @@ GameObject:
   - 114: {fileID: 11404056}
   m_Layer: 0
   m_Name: ParticleGlow
-  m_TagString: Untagged
+  m_TagString: ParticleGlow
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -116,7 +136,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &118256
 GameObject:
   m_ObjectHideFlags: 1
@@ -130,7 +150,7 @@ GameObject:
   - 114: {fileID: 11427838}
   m_Layer: 0
   m_Name: ParticleGlow
-  m_TagString: Untagged
+  m_TagString: ParticleGlow
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -185,7 +205,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &122676
 GameObject:
   m_ObjectHideFlags: 0
@@ -234,7 +254,7 @@ GameObject:
   - 114: {fileID: 11484330}
   m_Layer: 0
   m_Name: ParticleGlow
-  m_TagString: Untagged
+  m_TagString: ParticleGlow
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -252,7 +272,7 @@ GameObject:
   - 114: {fileID: 11452702}
   m_Layer: 0
   m_Name: ParticleGlow
-  m_TagString: Untagged
+  m_TagString: ParticleGlow
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -339,7 +359,7 @@ GameObject:
   - 114: {fileID: 11465520}
   m_Layer: 0
   m_Name: ParticleGlow
-  m_TagString: Untagged
+  m_TagString: ParticleGlow
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -430,7 +450,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &151032
 GameObject:
   m_ObjectHideFlags: 1
@@ -447,7 +467,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &154788
 GameObject:
   m_ObjectHideFlags: 0
@@ -558,7 +578,7 @@ GameObject:
   - 199: {fileID: 19930214}
   - 114: {fileID: 11487254}
   m_Layer: 0
-  m_Name: ParticleGlow
+  m_Name: LightBulbParticleGlow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -697,10 +717,9 @@ GameObject:
   - 222: {fileID: 22275138}
   - 114: {fileID: 11416760}
   - 225: {fileID: 22545264}
-  - 114: {fileID: 11435174}
   - 61: {fileID: 6108106}
   m_Layer: 0
-  m_Name: Image
+  m_Name: BlackOutCanvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -828,7 +847,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 154788}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 151.199997, y: 208.015228, z: 0}
+  m_LocalPosition: {x: 157.647095, y: 160.366852, z: 0}
   m_LocalScale: {x: 1.64864397, y: 1, z: 1}
   m_Children:
   - {fileID: 475660}
@@ -1122,6 +1141,19 @@ BoxCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Size: {x: 7.32999992, y: 10.0500002}
+--- !u!61 &6137562
+BoxCollider2D:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
+  m_Enabled: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_Offset: {x: .00216597388, y: .00817892142}
+  serializedVersion: 2
+  m_Size: {x: 5.82781363, y: 4.17713356}
 --- !u!61 &6140340
 BoxCollider2D:
   m_ObjectHideFlags: 1
@@ -1253,6 +1285,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db4816618afa845926af18eccff307, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  levelCompleteScriptActivated: 0
 --- !u!114 &11404330
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1417,6 +1450,33 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &11425168
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &11426036
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1444,6 +1504,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db4816618afa845926af18eccff307, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  levelCompleteScriptActivated: 0
 --- !u!114 &11432074
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1503,19 +1564,6 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!114 &11435174
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 193914}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8717d1b8f23d10247b6b78c0f476bcf1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerHidden: 0
-  flash: 0
 --- !u!114 &11440360
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1559,6 +1607,19 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &11443120
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8717d1b8f23d10247b6b78c0f476bcf1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerHidden: 0
+  flash: 0
 --- !u!114 &11443878
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1629,6 +1690,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ca75f74981cbfe4ba9420b5ea9a9204, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  blackOutImage: {fileID: 22545264}
+  defaultGlowColor: {r: 0, g: 0, b: 0, a: 0}
+  fadingSpeed: .25
+  atticRoom: {fileID: 154788}
   nextLevel: 0
   wall: {fileID: 145728}
 --- !u!114 &11452702
@@ -1642,6 +1707,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db4816618afa845926af18eccff307, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  levelCompleteScriptActivated: 0
 --- !u!114 &11459542
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1685,6 +1751,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db4816618afa845926af18eccff307, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  levelCompleteScriptActivated: 0
 --- !u!114 &11471204
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1818,6 +1885,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db4816618afa845926af18eccff307, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  levelCompleteScriptActivated: 0
 --- !u!114 &11487254
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1948,7 +2016,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -2105,7 +2173,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 725808120
       minMaxState: 0
     startSize:
       scalar: 6
@@ -2194,7 +2262,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -3001,7 +3069,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -3158,7 +3226,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 0
       minMaxState: 0
     startSize:
       scalar: 6
@@ -3247,7 +3315,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -4054,7 +4122,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -4211,7 +4279,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 725808120
       minMaxState: 0
     startSize:
       scalar: 6
@@ -4300,7 +4368,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -5107,7 +5175,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -5264,7 +5332,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 725808120
       minMaxState: 0
     startSize:
       scalar: 6
@@ -5353,7 +5421,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -6160,7 +6228,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -6317,7 +6385,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 725808120
       minMaxState: 0
     startSize:
       scalar: 6
@@ -6406,7 +6474,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -7213,7 +7281,7 @@ ParticleSystem:
   InitialModule:
     enabled: 1
     startLifetime:
-      scalar: 5
+      scalar: .0500000007
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -7370,7 +7438,7 @@ ParticleSystem:
         rgba: 4294967295
       maxColor:
         serializedVersion: 2
-        rgba: 4283954168
+        rgba: 725808120
       minMaxState: 0
     startSize:
       scalar: 6
@@ -7459,7 +7527,7 @@ ParticleSystem:
     enabled: 1
     m_Type: 0
     rate:
-      scalar: 10
+      scalar: 0
       maxCurve:
         serializedVersion: 2
         m_Curve:
@@ -8883,6 +8951,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 149600}
+--- !u!222 &22287426
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
 --- !u!222 &22294170
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -9101,6 +9175,23 @@ RectTransform:
   m_AnchoredPosition: {x: -.00400000019, y: .00499999989}
   m_SizeDelta: {x: 36.9000015, y: 21.2000008}
   m_Pivot: {x: .5, y: .5}
+--- !u!224 &22433202
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 22463864}
+  m_RootOrder: 0
+  m_AnchorMin: {x: .5, y: .5}
+  m_AnchorMax: {x: .5, y: .5}
+  m_AnchoredPosition: {x: 0, y: 2.38420739e-07}
+  m_SizeDelta: {x: 5.8499999, y: 4.19999981}
+  m_Pivot: {x: .5, y: .5}
 --- !u!224 &22439102
 RectTransform:
   m_ObjectHideFlags: 1
@@ -9130,10 +9221,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 22463864}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_AnchorMin: {x: .5, y: .5}
   m_AnchorMax: {x: .5, y: .5}
-  m_AnchoredPosition: {x: 0, y: 2.38420739e-07}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 5.8499999, y: 4.19999981}
   m_Pivot: {x: .5, y: .5}
 --- !u!224 &22450830
@@ -9217,6 +9308,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10.2008276, y: 6.3704524, z: 1}
   m_Children:
+  - {fileID: 22433202}
   - {fileID: 22450048}
   m_Father: {fileID: 444774}
   m_RootOrder: 1
@@ -9308,13 +9400,28 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!225 &22572656
+CanvasGroup:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 106488}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
-    m_Modifications: []
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: fadingSpeed
+      value: .25
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 154788}

--- a/Assets/Scripts/LevelControl/LevelComplete.cs
+++ b/Assets/Scripts/LevelControl/LevelComplete.cs
@@ -3,6 +3,29 @@ using System.Collections;
 
 public class LevelComplete : MonoBehaviour
 {
+	private float horzExtent;
+	//The alpha for the light bulb
+	private float bulbAlpha;
+	//Bool variable so the player can't activate the cutscene more than once
+	private bool cutsceneActivated;
+	//The canvas used in the cutscene to make the camera black out
+	public CanvasGroup blackOutImage;
+	//The original color of the particle system glow
+	public Color defaultGlowColor;
+	//The speed to how fast the fading in/out is
+	public float fadingSpeed = 0.25f;
+	//The variable used to change the alpha of objects
+	private float fadingAlpha;
+	//The variable used to change the alpha of objects that are appearing
+	private float appearingAlpha;
+	//The array of items
+	private GameObject[] itemsGlow;
+	//The light bulb
+	private GameObject bulb;
+	//The attic room
+	public GameObject atticRoom;
+	//The glow on the light bulb
+	private GameObject bulbGlow;
     public int nextLevel;
     Vector2 clickPosition;
     float clickOffsetY = 5;
@@ -18,7 +41,6 @@ public class LevelComplete : MonoBehaviour
     public GameObject wall;
     float wallMargin;
     const float wallOffset = 40;
-
     // Use this for initialization
     void Awake()
     {
@@ -26,29 +48,43 @@ public class LevelComplete : MonoBehaviour
     }
     void OnTriggerStay2D(Collider2D col)
     {
-        //used to make an offset that creates an area to click on, which can be increased/decreased by changing the constant.
-        float xNegPosition = transform.position.x - clickOffsetX;
-        float xPosPosition = transform.position.x + clickOffsetX;
-        float yPosPosition = transform.position.y + clickOffsetY;
-        float yNegPosition = transform.position.y - clickOffsetY;
+		//used to make an offset that creates an area to click on, which can be increased/decreased by changing the constant.
+		float xNegPosition = transform.position.x - clickOffsetX;
+		float xPosPosition = transform.position.x + clickOffsetX;
+		float yPosPosition = transform.position.y + clickOffsetY;
+		float yNegPosition = transform.position.y - clickOffsetY;
 
-        ///get position of click
-        clickPosition.x = Camera.main.ScreenToWorldPoint(Input.mousePosition).x;
-        clickPosition.y = Camera.main.ScreenToWorldPoint(Input.mousePosition).y;
+		///get position of click
+		clickPosition.x = Camera.main.ScreenToWorldPoint (Input.mousePosition).x;
+		clickPosition.y = Camera.main.ScreenToWorldPoint (Input.mousePosition).y;
 
-        if (col.tag == "Player" && ((Input.GetKeyDown(KeyCode.Space)) ||
-           ((yNegPosition < clickPosition.y && clickPosition.y < yPosPosition) &&
-            (xNegPosition < clickPosition.x && clickPosition.x < xPosPosition) &&
-            Input.GetMouseButtonDown(0))))
-        {
-            Debug.Log("Level completed");
-            EndingCutscene();
-        }
-    }
+		//Checks to see if the cutscene has been activated yet to prevent multiple instances of the cutscene
+		if (cutsceneActivated == false) 
+		{
+			if (col.tag == "Player" && ((Input.GetKeyDown (KeyCode.Space)) ||
+				((yNegPosition < clickPosition.y && clickPosition.y < yPosPosition) &&
+				(xNegPosition < clickPosition.x && clickPosition.x < xPosPosition) &&
+				Input.GetMouseButtonDown (0)))) {
+				Debug.Log ("Level completed");
+				EndingCutscene ();
+			}
+		}
+	}
 
     void EndingCutscene()
     {
         //setup
+		cutsceneActivated = false;		
+		//Get the horizontal extent of the camera
+		horzExtent = Camera.main.orthographicSize * Screen.width / Screen.height;
+		//Get the glow objects on items
+		itemsGlow = GameObject.FindGameObjectsWithTag ("ParticleGlow");
+		//Find the light bulb
+		bulb = GameObject.Find ("LightBulb_NOT_lit_1");
+		//Find the glow attached to the bulb
+		bulbGlow = GameObject.Find ("LightBulbParticleGlow");
+		//Get the color of the glow
+		defaultGlowColor = itemsGlow[itemsGlow.Length-1].GetComponent<ParticleSystem> ().startColor;
         player = GameObject.FindGameObjectWithTag("Player");
         cam = Camera.main.gameObject;
         pause = Camera.main.GetComponent<PauseScript>();
@@ -65,11 +101,15 @@ public class LevelComplete : MonoBehaviour
 
     IEnumerator _Cutscene()
     {
+		//Set to true so player won't be able to spam the cutscene
+		cutsceneActivated = true;
+		//WAit 0.5 seconds
         yield return new WaitForSeconds(0.5f);
 
         // Lock the camera once it finishes positioning itself
         cam.GetComponent<CameraFollowScript>().enabled = false;
 
+		//Wait 1 second
         yield return new WaitForSeconds(1);
 
         // Pan camera to left until it hits the wall
@@ -79,14 +119,82 @@ public class LevelComplete : MonoBehaviour
             yield return null;
         }
 
+		//Get the alpha value of an item
+		fadingAlpha = defaultGlowColor.a;
+
+		//While the alpha of the item is greater than 0
+		while (itemsGlow[itemsGlow.Length-1/*i*/].GetComponent<ParticleSystem>().startColor.a > 0f) 
+		{
+			//Decrease the alpha until it reaches 0
+			fadingAlpha  -= Time.deltaTime * fadingSpeed;
+			//Go through all the items so they fade away at the same rate
+			for(int i = 0; i < itemsGlow.Length; i++)
+			{
+				itemsGlow[i].GetComponent<ParticleSystem>().startColor = 
+					new Color(defaultGlowColor.r,defaultGlowColor.g,defaultGlowColor.b,fadingAlpha);
+			}
+			yield return null;
+		}
+		//Reset the fading alpha
+		fadingAlpha = defaultGlowColor.a;
+
+		//Move the bulb above the UI
+		bulb.GetComponent<SpriteRenderer> ().sortingLayerName = "AboveUI";
+
+		//Move the glow above the UI
+		bulbGlow.GetComponent<ParticleSystem> ().GetComponent<Renderer> ().sortingLayerName = "AboveUI";
+
+		//Wait 3 seconds
         yield return new WaitForSeconds(3);
 
-        // pan back to player
-        while (cam.transform.position.x < player.transform.position.x)
-        {
+		// pan back to the right side of the wall
+		while ((cam.transform.position.x+horzExtent) < 
+		       (atticRoom.transform.position.x + atticRoom.GetComponent<Renderer> ().bounds.extents.x))
+		{
             cam.transform.position += new Vector3(0.2f, 0, 0);
             yield return null;
         }
+		//Set the correct R,G,B values for the glow but alpha to 0
+		bulbGlow.GetComponent<ParticleSystem> ().startColor = 
+			new Color (defaultGlowColor.r,defaultGlowColor.g,defaultGlowColor.b, 0);
+
+		//Loop to make the glow on the bulb appear.
+		while (bulbGlow.GetComponent<ParticleSystem>().startColor.a < defaultGlowColor.a) 
+		{
+			appearingAlpha += Time.deltaTime*fadingSpeed;
+			bulbGlow.GetComponent<ParticleSystem>().startColor = 
+				new Color(defaultGlowColor.r,defaultGlowColor.g,defaultGlowColor.b,appearingAlpha);
+			yield return null;
+		}
+
+		//Loop to make the camera black out
+		while (blackOutImage.alpha  < 1f) 
+		{
+			blackOutImage.alpha += Time.deltaTime*fadingSpeed;
+			yield return null;
+		}
+
+		//Wait 1 second
+		yield return new WaitForSeconds(1);
+
+		//Different alpha needed since the bulb alpha and bulbGlow alpha are different
+		bulbAlpha = bulb.GetComponent<Renderer> ().material.color.a;
+
+		//While the bulb is still visible make it fade
+		while (bulbGlow.GetComponent<ParticleSystem>().startColor.a > 0f) 
+		{
+			//Make the glow fade when the bulb alpha is smaller than the bulbGlow alpha
+			if(bulb.GetComponent<Renderer>().material.color.a < bulbGlow.GetComponent<ParticleSystem>().startColor.a)
+			{
+				fadingAlpha  -= Time.deltaTime * fadingSpeed;
+				bulbGlow.GetComponent<ParticleSystem>().startColor = 
+					new Color(defaultGlowColor.r,defaultGlowColor.g,defaultGlowColor.b,fadingAlpha);
+			}
+			bulbAlpha -= Time.deltaTime*fadingSpeed;
+			bulb.GetComponent<Renderer>().material.color = new Color(1,1,1,bulbAlpha);
+			yield return null;
+		}
+		yield return new WaitForSeconds (3);
         cam.GetComponent<CameraFollowScript>().enabled = true;
         //prevent player from moving until end of cutscene
         playerScript.normalSpeed = playerScript.defaultSpeed;

--- a/Assets/Scripts/LevelControl/ParticleCollider.cs
+++ b/Assets/Scripts/LevelControl/ParticleCollider.cs
@@ -12,7 +12,8 @@ public class ParticleCollider : MonoBehaviour {
     
 	// Use this for initialization
 	void Start () {
-        particle.emissionRate = 0;
+		particle.emissionRate = 0;
+		particle.startLifetime = 0;
 	}
 	
 	// Update is called once per frame
@@ -24,7 +25,7 @@ public class ParticleCollider : MonoBehaviour {
     {
         if (col.gameObject.tag == "Player")
         {
-            particle.emissionRate = 1;
+            particle.emissionRate = 6;
             particle.startLifetime = 1;
         }
     }

--- a/Assets/Scripts/LevelControl/ParticleGlow.cs
+++ b/Assets/Scripts/LevelControl/ParticleGlow.cs
@@ -36,8 +36,9 @@ public class ParticleGlow : MonoBehaviour {
         else
         {
            // particle.Play();
-            particle.emissionRate = 1;
-            particle.startLifetime = 1;
+			particle.emissionRate = 6;
+			particle.startLifetime = 1;
+		
         }
     }
 /*

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,6 +13,7 @@ TagManager:
   - Bug
   - BugWall
   - Item
+  - ParticleGlow
   layers:
   - Default
   - TransparentFX
@@ -61,4 +62,7 @@ TagManager:
     locked: 0
   - name: UI
     uniqueID: 3529074763
+    locked: 0
+  - name: AboveUI
+    uniqueID: 3770508221
     locked: 0


### PR DESCRIPTION
The level complete cutscene is implemented. The camera centers on the
items, the glow fades away, camera pans back to the player/bed/light
bulb section of the room, the light bulb glows, camera goes black with
light bulb and glow still visible, then finally the light bulb and glow
fades out and the next level is loaded.

Additional changes needed:
The MapManager prefab for the AtticLevel was updated.
-Tags were added to the item glow object to make searching for them to
put into an array easier.
-Light bulb glow name was changed to make searching easier
-A black out canvas was added to make the camera black out during the
cutscene

Additional tags implemented
-ParticleGlow tag included to make things easier
-"AboveUI" layout used to make the light bulb and light bulb glow stay
visible when the camera blacks out.

Emissions rate for the glow particles increased to 6 to make fade in/out
less choppy.
Color was changed in respect with the emissions rate change to make the
particle look very similar to the original particle effect.
