### PR TITLE
upon retry several monster types are frozen

### DIFF
--- a/Assets/Scripts/LevelControl/LevelControl.cs
+++ b/Assets/Scripts/LevelControl/LevelControl.cs
@@ -9,6 +9,7 @@ public class LevelControl : MonoBehaviour
     public float timer = 5.0f;
    // float fadeTime = 3.0f;    //disabled for compiler error -joel
     GameObject player;
+	PlayerControl playerScript;
     public GameObject overlay;
     Image overlay_image;
     GameObject gameOverPanel;
@@ -24,6 +25,7 @@ public class LevelControl : MonoBehaviour
        // spottedCue = GameObject.Find("SpottedIndicator");
        // spottedCue.SetActive(false);
         player = GameObject.Find("Player");
+		playerScript = GameObject.FindWithTag ("Player").GetComponent<PlayerControl> ();
         audioHandler = GameObject.Find("AudioHandler").GetComponent<AudioHandlerScript>();
         // set the initial position of the player
         initialPlayerPos = player.transform.position;
@@ -89,6 +91,13 @@ public class LevelControl : MonoBehaviour
 
         // Resume time
         Time.timeScale = 1f;
+		//resumes hunter speed and resets position
+		playerScript.hunterScript.isCaught = false;
+		playerScript.hunterScript.speed = 5.0f;
+		playerScript.hunterScript.transform.position = playerScript.hunterScript.originalPosition;
+		//resumes chasing monster speed
+		playerScript.chasingMonsterScript.speedNormal = 2.0f;
+		playerScript.chasingMonsterScript.speedChasing = 4.0f;
         //play intro music
         audioHandler.PlayMusic(3);
     }

--- a/Assets/Scripts/Monster/ChasingMonster.cs
+++ b/Assets/Scripts/Monster/ChasingMonster.cs
@@ -226,9 +226,11 @@ public class ChasingMonster : MonoBehaviour
     //When the player collides with the patrolling enemy
     void OnTriggerEnter2D(Collider2D col)
     {
+		player.chasingMonsterScript = this;
         //If the player collides with the patrolling enemy and not hiding
         if (col.gameObject.tag == "Player" && player.hide == false)
         {
+
             // Stop the monster; it will not be able to return to the normal speed.
             speedNormal = speedChasing = 0;
 

--- a/Assets/Scripts/Monster/Hunter.cs
+++ b/Assets/Scripts/Monster/Hunter.cs
@@ -9,7 +9,7 @@ public class Hunter : MonoBehaviour
    // public AudioClip[] hunterClips;
 
     public bool facingRight = true;
-    private bool isCaught = false;
+    public bool isCaught = false;
     public float movement;
     public float speed = 5.0f;
     public float counter = 0;
@@ -25,6 +25,9 @@ public class Hunter : MonoBehaviour
 	
 	// Distance to player
 	private Vector2 playerDistance;
+
+	// Original position
+	public Vector3 originalPosition;
 
     //Variable to set distance of the monster's vision
     float lineCastDistance = 14f;
@@ -47,6 +50,8 @@ public class Hunter : MonoBehaviour
     public GameObject fogLeft;
     public GameObject fogRight;
 
+	//public Vector3 originalPosition;
+
     void Awake()
     {
         //spottedCue = GameObject.Find("SpottedIndicator");  // BUGGED NULL REFERENCE
@@ -57,9 +62,15 @@ public class Hunter : MonoBehaviour
         //set player to the object with tag "Player"
         player = GameObject.FindWithTag("Player").GetComponent<PlayerControl>();
 
-		
+		//Get Position
+		originalPosition = new Vector3 (this.transform.position.x, this.transform.position.y, this.transform.position.z);
+
+
 		// Initialize player distance
 		playerDistance = new Vector2(0f, 0f); 
+
+		//retry restarts movement
+		//speed = 5.0f;
 
     }
 
@@ -200,13 +211,14 @@ public class Hunter : MonoBehaviour
         theScale.x *= -1;
         transform.localScale = theScale;
     }
-
     //When the player collides with the patrolling enemy
     void OnTriggerEnter2D(Collider2D col)
     {
         //If the player collides with the patrolling enemy and is not caught
         if (col.gameObject.tag == "Player" && isCaught)
         {
+			//stores instance of this in player
+			player.hunterScript = this;
             //Monster stops moving
             speed = 0;
             //If monster is facing left and the player is behind the monster OR monster is facing

--- a/Assets/Scripts/Player/PlayerControl.cs
+++ b/Assets/Scripts/Player/PlayerControl.cs
@@ -33,6 +33,12 @@ public class PlayerControl : MonoBehaviour
     public float slowMoSpeed;        //speed magnitude when slowMo is activaed
     public float sprintSpeed;
 
+	//Hunter Script
+	public Hunter hunterScript = null;
+
+	//chasing monster script
+	public ChasingMonster chasingMonsterScript = null;
+
 	//Fading Darkness Script variable
 	public FadingDarkness fadingDarknessScript;
 


### PR DESCRIPTION
hunter monster has been fixed upon restart the hunter can move again an
also starts from its original position, the chasing monster speed is
changed to 0 upon death, has been changed so that upon retry speed is
reset to its normal values(has not been tested yet but theoretically
should fix the problem), no issues with patrolling type monster upon
trial
