### PR TITLE
Improve 4th Wall Bug

### DIFF
--- a/Assets/Prefabs/MapManager/HallucinationRoomBug.prefab
+++ b/Assets/Prefabs/MapManager/HallucinationRoomBug.prefab
@@ -186,25 +186,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &158002
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 415754}
-  - 212: {fileID: 21295426}
-  - 61: {fileID: 6139002}
-  - 114: {fileID: 11495298}
-  - 95: {fileID: 9576722}
-  m_Layer: 0
-  m_Name: CameraBug
-  m_TagString: Bug
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &158366
 GameObject:
   m_ObjectHideFlags: 0
@@ -415,7 +396,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 178598}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 668.921509, y: 87.4110641, z: 0}
+  m_LocalPosition: {x: 161.317749, y: 11.6368885, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 487718}
@@ -428,7 +409,6 @@ Transform:
   - {fileID: 433036}
   - {fileID: 493884}
   - {fileID: 474264}
-  - {fileID: 415754}
   - {fileID: 489424}
   - {fileID: 447726}
   - {fileID: 436370}
@@ -451,7 +431,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 14
+  m_RootOrder: 13
 --- !u!4 &409208
 Transform:
   m_ObjectHideFlags: 1
@@ -463,7 +443,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 15
+  m_RootOrder: 14
 --- !u!4 &409216
 Transform:
   m_ObjectHideFlags: 1
@@ -475,19 +455,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 17
---- !u!4 &415754
-Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158002}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: .599990845, y: .399999619, z: -9}
-  m_LocalScale: {x: 1.5, y: 1.5, z: 2.67529035}
-  m_Children: []
-  m_Father: {fileID: 401008}
-  m_RootOrder: 10
+  m_RootOrder: 16
 --- !u!4 &431816
 Transform:
   m_ObjectHideFlags: 1
@@ -499,7 +467,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 16
+  m_RootOrder: 15
 --- !u!4 &433036
 Transform:
   m_ObjectHideFlags: 1
@@ -523,7 +491,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 13
+  m_RootOrder: 12
 --- !u!4 &447726
 Transform:
   m_ObjectHideFlags: 1
@@ -535,7 +503,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 12
+  m_RootOrder: 11
 --- !u!4 &448982
 Transform:
   m_ObjectHideFlags: 1
@@ -571,7 +539,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 19
+  m_RootOrder: 18
 --- !u!4 &474264
 Transform:
   m_ObjectHideFlags: 1
@@ -619,7 +587,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 18
+  m_RootOrder: 17
 --- !u!4 &487718
 Transform:
   m_ObjectHideFlags: 1
@@ -643,7 +611,7 @@ Transform:
   m_LocalScale: {x: .5, y: .5, z: .533431649}
   m_Children: []
   m_Father: {fileID: 401008}
-  m_RootOrder: 11
+  m_RootOrder: 10
 --- !u!4 &493884
 Transform:
   m_ObjectHideFlags: 1
@@ -860,19 +828,6 @@ BoxCollider2D:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 151966}
-  m_Enabled: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Size: {x: .49000001, y: .230000004}
---- !u!61 &6139002
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158002}
   m_Enabled: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
@@ -1198,23 +1153,6 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
---- !u!95 &9576722
-Animator:
-  serializedVersion: 3
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158002}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 9f8d5d6694edbfa458fd34c5fc9ab8a4, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
 --- !u!95 &9590184
 Animator:
   serializedVersion: 3
@@ -1447,22 +1385,6 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 167292}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95d00fcee7f28424b93810cbeb32fcc9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  touchedWall: 0
-  speed: 8
-  timeMin: 2
-  timeMax: 3
-  isMoving: 0
---- !u!114 &11495298
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158002}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 95d00fcee7f28424b93810cbeb32fcc9, type: 3}
@@ -1970,32 +1892,6 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 17d49d701c8c06542b1926ce58ba3686, type: 3}
   m_Color: {r: 0, g: 1, b: 0, a: 1}
---- !u!212 &21295426
-SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 158002}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_ImportantGI: 0
-  m_AutoUVMaxDistance: .5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: -765892533
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 7032a4e85ef9eb54cabaeb6f859c7c74, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!212 &21295682
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -487,6 +487,52 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b6dea17aecb4e4d4e94b43e7f6b1b0b4, type: 2}
   m_IsPrefabParent: 0
+--- !u!1001 &134716550
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1052240072}
+    m_Modifications:
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 157.199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &134716551 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_PrefabInternal: {fileID: 134716550}
 --- !u!1001 &179147063
 Prefab:
   m_ObjectHideFlags: 0
@@ -2439,6 +2485,7 @@ Transform:
   m_Children:
   - {fileID: 1222927758}
   - {fileID: 179147064}
+  - {fileID: 134716551}
   m_Father: {fileID: 0}
   m_RootOrder: 1
 --- !u!1 &1070238865

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -1477,6 +1477,52 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 416192, guid: 7ec75d43b56ce734ebf9259766d39a06, type: 2}
   m_PrefabInternal: {fileID: 523477443}
+--- !u!1001 &528849976
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1052240072}
+    m_Modifications:
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 157.199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &528849977 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_PrefabInternal: {fileID: 528849976}
 --- !u!1001 &540115933
 Prefab:
   m_ObjectHideFlags: 0
@@ -2874,7 +2920,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 485740, guid: dd2ddaae2f1306442a88d697beccfaff, type: 2}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 154038, guid: dd2ddaae2f1306442a88d697beccfaff, type: 2}
       propertyPath: m_Name
@@ -2957,6 +3003,7 @@ Transform:
   m_Children:
   - {fileID: 597182136}
   - {fileID: 962209804}
+  - {fileID: 528849977}
   m_Father: {fileID: 0}
   m_RootOrder: 1
 --- !u!1 &1070238865

--- a/Assets/Scenes/Level3.unity
+++ b/Assets/Scenes/Level3.unity
@@ -3294,6 +3294,52 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 506d143f33e895343b4b4b9a2f367f00, type: 2}
   m_IsPrefabParent: 0
+--- !u!1001 &1253530362
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1393586455}
+    m_Modifications:
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 157.199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1253530363 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_PrefabInternal: {fileID: 1253530362}
 --- !u!1 &1283912579
 GameObject:
   m_ObjectHideFlags: 0
@@ -3980,6 +4026,7 @@ Transform:
   m_Children:
   - {fileID: 1312613297}
   - {fileID: 387019093}
+  - {fileID: 1253530363}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!114 &1393586456

--- a/Assets/Scenes/MapManagerTesting.unity
+++ b/Assets/Scenes/MapManagerTesting.unity
@@ -1824,6 +1824,48 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 34
+--- !u!1001 &941327453
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1052240072}
+    m_Modifications:
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 157.199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_IsPrefabParent: 0
 --- !u!4 &967527253 stripped
 Transform:
   m_PrefabParentObject: {fileID: 416192, guid: 7ec75d43b56ce734ebf9259766d39a06, type: 2}
@@ -1928,6 +1970,10 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 42c4655a7a1da6644bc03117912e9d98, type: 2}
   m_IsPrefabParent: 0
+--- !u!4 &1052240072 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 435054, guid: 42c4655a7a1da6644bc03117912e9d98, type: 2}
+  m_PrefabInternal: {fileID: 1052240071}
 --- !u!1 &1070238865
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Nightmare.unity
+++ b/Assets/Scenes/Nightmare.unity
@@ -146,6 +146,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 880d648e39408764498f04333e23785b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &241476706
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1549187587}
+    m_Modifications:
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 157.199997
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -9
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 401708, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: edf146eb1a9a3254591051e58e7310ac, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1001 &293566400
 Prefab:
   m_ObjectHideFlags: 0
@@ -283,6 +325,10 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 42c4655a7a1da6644bc03117912e9d98, type: 2}
   m_IsPrefabParent: 0
+--- !u!4 &1549187587 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 435054, guid: 42c4655a7a1da6644bc03117912e9d98, type: 2}
+  m_PrefabInternal: {fileID: 1549187586}
 --- !u!1001 &1712454360
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LevelControl/BugScript.cs
+++ b/Assets/Scripts/LevelControl/BugScript.cs
@@ -5,6 +5,7 @@ using System.Collections;
 //There MUST be instances of the bug for the hallucination room to take affect
 //20+ instances of the bugs make for better hallucination effects 
 //However too many will decrease performance of the game
+//The Camera bug MUST be attached to the camera for it to move with and stay inside the camera screen
 public class BugScript : MonoBehaviour 
 {
 	//The array of bugs
@@ -49,28 +50,36 @@ public class BugScript : MonoBehaviour
 		//Set change direction and timer so that the bug spawns in a random rotation
 		changeDirectionTime = Random.Range (timeMin,timeMax);
 		timer = changeDirectionTime - 0.01f;
+		//Search through the bugArray to find the Camera Bug
+		for (int i = 0; i < bugArray.Length; i++) 
+		{
+			if (bugArray [i].name.Contains ("Camera")) 
+			{
+				CamBug = bugArray [i];
+			}
+		}
 	}
 	
 	// Update is called once per frame
 	void Update () 
-	{
-		//Loop through the bug array
-		for (int i = 0; i < bugArray.Length; i++) 
-		{
-			//If the bug is a camera bug
-			if (bugArray [i].name.Contains ("Camera")) 
-			{
-				CamBug = bugArray [i];
-				//and if the camera bug is moving
-				if (CamBug.GetComponent<BugScript> ().isMoving) 
-				{					
-					//Ignore the collision of the bug and the camera bug
-					Physics2D.IgnoreCollision (bugPos.GetComponent<Collider2D> (), 
-					                           CamBug.transform.GetComponent<Collider2D>(),
-					                           true);
-				}
-			}
-		}
+	{				
+		//for (int i = 0; i < bugArray.Length; i++) 
+		//{
+		//	if (bugArray [i].name.Contains ("Camera")) 
+		//	{
+		//		CamBug = bugArray [i];
+		//		if(CamBug.GetComponent<BugScript>().isMoving)
+		//		{
+		//			Physics2D.IgnoreCollision (bugPos.GetComponent<Collider2D> (), 
+		//			                           CamBug.transform.GetComponent<Collider2D>(),
+		//			                           true);
+		//		}
+		//	}
+		//}
+		//Ignore the collision of the bug and the camera bug
+		Physics2D.IgnoreCollision (bugPos.GetComponent<Collider2D> (), 
+			                       CamBug.transform.GetComponent<Collider2D>(),
+			                       true);		
 		//Ignore the collision of the bug and the player
 		Physics2D.IgnoreCollision (bugPos.GetComponent<Collider2D> (), 
 		                           playerPos.GetComponent<Collider2D> (), true);
@@ -97,7 +106,7 @@ public class BugScript : MonoBehaviour
 			rotationVector.x = 0f;
 			rotationVector.y = 0f;
 			//rotate the bug
-			bugPos.Rotate(rotationVector);
+			bugPos.Rotate(rotationVector*5);
 			//reset the timer
 			timer -= changeDirectionTime;
 		}


### PR DESCRIPTION
In all applicable scenes the camera bug must be attached to the camera
for it to follow and stay inside the camera. I believe I have covered
all the scenes necessary but if I have missed any just attach a camera
bug to the camera.

I moved the for loop to search for the bug from update to start as this
is more efficient if there is only going to be one camera bug. If in the
future more is desired just de-comment the for loop in update and attach
any new camera bugs to the camera.

I increased the degree of which the bugs change direction to give them
more of a random movement rather than before where they changed
direction only a tiny bit.
